### PR TITLE
feat/ MR-53

### DIFF
--- a/sistema-taller/pom.xml
+++ b/sistema-taller/pom.xml
@@ -92,6 +92,14 @@
 	<build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>

--- a/sistema-taller/src/test/java/com/taller/sistema_taller/service/user_service/UserServiceTest.java
+++ b/sistema-taller/src/test/java/com/taller/sistema_taller/service/user_service/UserServiceTest.java
@@ -1,0 +1,95 @@
+package com.taller.sistema_taller.service.user_service;
+
+import com.taller.sistema_taller.dto.LoginDTO;
+import com.taller.sistema_taller.dto.UserDTO;
+import com.taller.sistema_taller.model.UserAccounts.ClientAccount;
+import com.taller.sistema_taller.model.UserAccounts.UserAccount;
+import com.taller.sistema_taller.repositories.UserAccountRepository;
+import com.taller.sistema_taller.service.user_service.user_validations.UserValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
+
+    @Mock
+    private UserValidator userValidator;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("Debería registrar un cliente exitosamente cuando los datos son válidos")
+    void registerUser_ShouldReturnSavedUser_WhenDataIsValid() {
+        
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUserName("Juan Perez");
+        userDTO.setPhone("9999999999");
+        userDTO.setEmail("juan.perez@test.com");
+        userDTO.setPassword("Password123!");
+
+        String userType = "CLIENT";
+
+        UserAccount expectedUser = new ClientAccount(
+                1L,
+                userDTO.getUserName(),
+                userDTO.getPhone(),
+                userDTO.getEmail(),
+                userDTO.getPassword()
+        );
+
+        doNothing().when(userValidator).validateRegisterData(userDTO, userType);
+        when(userAccountRepository.save(any(UserAccount.class))).thenReturn(expectedUser);
+
+        
+        UserAccount result = userService.registerUser(userDTO, userType);
+
+        
+        assertNotNull(result);
+        assertTrue(result instanceof ClientAccount);
+        assertEquals("Juan Perez", result.getUserName());
+        assertEquals("juan.perez@test.com", result.getAccessCredentials().getEmail());
+
+        verify(userValidator, times(1)).validateRegisterData(userDTO, userType);
+        verify(userAccountRepository, times(1)).save(any(UserAccount.class));
+    }
+
+    @Test
+    @DisplayName("Debería autenticar un usuario exitosamente")
+    void authenticateUser_ShouldReturnUser_WhenCredentialsAreValid() {
+        
+        LoginDTO loginDTO = new LoginDTO();
+        loginDTO.setEmail("juan.perez@test.com");
+        loginDTO.setPassword("Password123!");
+
+        UserAccount existingUser = new ClientAccount(
+                1L, "Juan Perez", "9999999999", "juan.perez@test.com", "Password123!"
+        );
+
+        when(userAccountRepository.findByAccessCredentialsEmail(loginDTO.getEmail()))
+                .thenReturn(Optional.of(existingUser));
+
+        
+        UserAccount result = userService.authenticateUser(loginDTO);
+
+        
+        assertNotNull(result);
+        assertEquals(existingUser.getUserId(), result.getUserId());
+        assertEquals(existingUser.getAccessCredentials().getEmail(), result.getAccessCredentials().getEmail());
+        
+        verify(userAccountRepository, times(1)).findByAccessCredentialsEmail(loginDTO.getEmail());
+    }
+}

--- a/sistema-taller/src/test/java/com/taller/sistema_taller/service/vehicle_service/ClientVehicleServiceTest.java
+++ b/sistema-taller/src/test/java/com/taller/sistema_taller/service/vehicle_service/ClientVehicleServiceTest.java
@@ -1,0 +1,95 @@
+package com.taller.sistema_taller.service.vehicle_service;
+
+import com.taller.sistema_taller.dto.ClientVehicleDTO;
+import com.taller.sistema_taller.model.VehicleManagement.ClientVehicle;
+import com.taller.sistema_taller.repositories.ClientVehicleRepository;
+import com.taller.sistema_taller.service.vehicle_service.vehicle_validations.ClientVehicleValidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClientVehicleServiceTest {
+
+    @Mock
+    private ClientVehicleRepository clientVehicleRepository;
+
+    @Mock
+    private ClientVehicleValidator clientVehicleValidator;
+
+    @InjectMocks
+    private ClientVehicleService clientVehicleService;
+
+    @Test
+    @DisplayName("Debería registrar un vehículo exitosamente cuando los datos de entrada son válidos")
+    void registerVehicle_ShouldReturnSavedVehicle_WhenDataIsValid() {
+        
+        ClientVehicleDTO vehicleDTO = new ClientVehicleDTO();
+        vehicleDTO.setClientId(1L);
+        vehicleDTO.setBrand("Toyota");
+        vehicleDTO.setModel("Corolla");
+        vehicleDTO.setYear(2022);
+        vehicleDTO.setLicensePlate("XYZ123");
+        vehicleDTO.setMileage(15000);
+        vehicleDTO.setFuelLevel(0.5f);
+        vehicleDTO.setAdditionalObservations("Ninguna");
+
+        
+        ClientVehicle expectedVehicle = new ClientVehicle(
+            vehicleDTO.getClientId(),
+            new com.taller.sistema_taller.model.VehicleManagement.StaticVehicleData("Toyota", "Corolla", 2022, "XYZ123"),
+            new com.taller.sistema_taller.model.VehicleManagement.NonStaticVehicleData(15000, 0.5f, "Ninguna")
+        );
+
+        
+        doNothing().when(clientVehicleValidator).validateClientVehicle(vehicleDTO);
+        when(clientVehicleRepository.save(any(ClientVehicle.class))).thenReturn(expectedVehicle);
+
+        
+        ClientVehicle result = clientVehicleService.registerVehicle(vehicleDTO);
+
+        
+        assertNotNull(result);
+        assertEquals(1L, result.getClientId());
+        assertEquals("Toyota", result.getStaticVehicleData().getBrand());
+        assertEquals("Corolla", result.getStaticVehicleData().getModel());
+        
+        
+        verify(clientVehicleValidator, times(1)).validateClientVehicle(vehicleDTO);
+        verify(clientVehicleRepository, times(1)).save(any(ClientVehicle.class));
+    }
+    
+    @Test
+    @DisplayName("Debería encontrar un vehículo exitosamente por ID")
+    void findVehicleById_ShouldReturnVehicle_WhenIdExists() {
+        
+        String vehicleId = "VEH-123";
+        ClientVehicle expectedVehicle = new ClientVehicle(
+            1L,
+            new com.taller.sistema_taller.model.VehicleManagement.StaticVehicleData("Nissan", "Sentra", 2020, "ABC1234"),
+            new com.taller.sistema_taller.model.VehicleManagement.NonStaticVehicleData(30000, 0.7f, "Todo bien")
+        );
+        expectedVehicle.setIdVehicle(vehicleId);
+
+        when(clientVehicleRepository.findById(vehicleId)).thenReturn(Optional.of(expectedVehicle));
+
+        
+        ClientVehicle result = clientVehicleService.findVehicleById(vehicleId);
+
+        
+        assertNotNull(result);
+        assertEquals(vehicleId, result.getIdVehicle());
+        assertEquals("Nissan", result.getStaticVehicleData().getBrand());
+        
+        verify(clientVehicleRepository, times(1)).findById(vehicleId);
+    }
+}


### PR DESCRIPTION
## Descripción
Este PR introduce pruebas unitarias utilizando JUnit 5 y Mockito para asegurar la estabilidad de la lógica de negocio en la capa de servicios sin requerir la carga del contexto de Spring Boot ni conexión a base de datos.

## Cambios realizados
- Creación de `UserServiceTest` para probar el registro y autenticación de usuarios.
- Creación de `ClientVehicleServiceTest` para probar el registro y búsqueda de vehículos.
- Configuración de `maven-surefire-plugin` (ByteBuddy workaround) en `pom.xml` para garantizar compatibilidad con la JVM de Java 24.
- Agregados los documentos de planificación y pruebas en `docs-mantenimiento/plan_y_pruebas_MR-53.md`.

## Verificación
- [x] Los tests se ejecutan correctamente con `./mvnw test` en tiempo récord (~0.47s por clase).
- [x] Plantillas de QA completadas y aprobadas.
